### PR TITLE
fix how showCommand treats ACTION

### DIFF
--- a/Network/SimpleIRC/Messages.hs
+++ b/Network/SimpleIRC/Messages.hs
@@ -203,5 +203,5 @@ showCommand (MNick    nick)                 = "NICK " `B.append` nick
 showCommand (MNotice  chan msg)             = "NOTICE " `B.append` chan `B.append`
                                               " :" `B.append` msg
 showCommand (MAction  chan msg)             = showCommand $ MPrivmsg chan
-                                              ("\x01ACTION " `B.append` msg
-                                              `B.append` "\x01")
+                                              ("\SOHACTION " `B.append` msg
+                                              `B.append` "\SOH")


### PR DESCRIPTION
Hi!  Thank you for the great library, it's helped me out a bunch over the years :)

This PR should fix #23 -- The official IRC RFC specifies `"\x01" ++ "ACTION"`, but unfortunately the literal `"\x01ACTION"` in Haskell is parsed as `"\428TION"`, since it treats `\x01ac` as an entire character.  So the raw bytestring sent is `"\428TION"`

This replaces the literal with `"\SOHACTION"`, which should get the desired result :)